### PR TITLE
Fix Amplify build: add Bun build spec

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,24 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        # Amplify's build image ships npm, not Bun — install Bun (pinned to the
+        # version the lockfile was generated with) and put it on PATH.
+        - curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13"
+        - export BUN_INSTALL="$HOME/.bun"
+        - export PATH="$BUN_INSTALL/bin:$PATH"
+        - bun install --frozen-lockfile
+    build:
+      commands:
+        - export BUN_INSTALL="$HOME/.bun"
+        - export PATH="$BUN_INSTALL/bin:$PATH"
+        - bun run build
+  artifacts:
+    baseDirectory: dist
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*
+      - $HOME/.bun/**/*


### PR DESCRIPTION
## Problem
After the move to Bun, `package-lock.json` is gone, so Amplify's default `npm ci && npm run build` fails — Amplify "doesn't know how to build" the site anymore.

## Fix
Add `amplify.yml` so Amplify builds with Bun:
- Installs Bun in `preBuild` (pinned to `1.3.13`, the version `bun.lock` was generated with) and puts it on `PATH`.
- Runs `bun install --frozen-lockfile`, then `bun run build`.
- Publishes the Vite output from `dist/`, and caches `node_modules` + `~/.bun`.

## Verification
- `bun install --frozen-lockfile` passes locally (lockfile in sync).
- Clean `bun run build` produces `dist/index.html` + assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)